### PR TITLE
Fix #321

### DIFF
--- a/templates/grid/ajax_grid_list.html
+++ b/templates/grid/ajax_grid_list.html
@@ -2,7 +2,7 @@
 <div id="target">
     <h2>{% if grids.count %}{% trans "Grids" %}{% else %}{% trans "No grids found" %}{% endif %}</h2>
     {% if grids.count %}
-        <p class="clickable">{% trans "Click a grid to add your grid to it." %}</p>      
+        <p class="clickable">{% trans "Click a grid to add your package to it." %}</p>      
     {% endif %}
     {% for grid in grids %}
   

--- a/templates/package/includes/_attach_grid.html
+++ b/templates/package/includes/_attach_grid.html
@@ -1,7 +1,8 @@
 <form id="find-a-grid-form" action="" method="post" style="display: none;">
     {% csrf_token %}
+    <h2>Search for a grid</h2>
     <input type="hidden" name="redirect" value="{% url 'package' package.slug %}" />                
-    <input type="text" name="search-field" id="find-a-grid-input" value="" autocomplete="off" />
+    <input type="text" name="search-field" id="find-a-grid-input" value="" autocomplete="off" placeholder="Grid name" />
     <input name="package" id="package-field" value="{{ package.id }}" type="hidden" />    
     <div id="target-parent"><div id="target"></div></div>
 </form>

--- a/templates/package/package.html
+++ b/templates/package/package.html
@@ -208,7 +208,6 @@
         <div class="pull-right">
           {% if request.user.is_authenticated and profile.can_add_grid %}        
             <a id="find-a-grid" href="#"><span class="glyphicon glyphicon-plus"></span></a>
-            {% include "package/includes/_attach_grid.html" %}            
           {% endif %}
         </div>
       </div>
@@ -216,11 +215,10 @@
       <div class="panel-body">
         {% for grid in package.grids %}            
           <a href="{% url 'grid' grid.slug %}" title="{{ grid.description }}">{{ grid }}</a> &nbsp;
-        {% empty %}
-          {% if request.user.is_authenticated and profile.can_add_grid %}
-            {% include "package/includes/_attach_grid.html" %}
-          {% endif %}
         {% endfor %}
+        {% if request.user.is_authenticated and profile.can_add_grid %}
+          {% include "package/includes/_attach_grid.html" %}
+        {% endif %}
       </div>
     </div>
     <!-- end Grids panel -->


### PR DESCRIPTION
This fixes #321 

The ``_attach_grid.html`` template was included twice by package.html when the package was on no grids. The js in ``ajax_grid_list.html`` then submitted both within a few ms, triggering a race condition in ``grid.views.add_grid_package`` which meant it was sometimes added twice.

This change removes the grid search form from the panel title and always includes the panel body form (permission permitting). The search form now has a title to improve layout, and the help text has been corrected.