### PR TITLE
Fixed copyright year in footer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys, time, os
 
 # todo: see if VIRTUAL_ENV variable is in the paths
 # and if it is not, add to os.path - this is necessary when sphinx is
@@ -52,7 +52,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Django Packages'
-copyright = u'2010-2015, Audrey Roy Greenfeld, Daniel Roy Greenfeld and contributors'
+copyright = u'2010-{year}, Audrey Roy Greenfeld, Daniel Roy Greenfeld and contributors'.format(year=time.strftime('%Y'))
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/static/error.html
+++ b/static/error.html
@@ -48,7 +48,7 @@
   <div class="container">
       <div class="row">
           <div class="col-12">
-              &copy; 2010-2015 <a href="http://pydanny.com">Daniel</a> and <a href="http://www.audreyr.com">Audrey</a> Roy Greenfeld
+              &copy; 2010-2016 <a href="http://pydanny.com">Daniel</a> and <a href="http://www.audreyr.com">Audrey</a> Roy Greenfeld
           </div>
       </div>
   </div>

--- a/static/maintenance.html
+++ b/static/maintenance.html
@@ -46,7 +46,7 @@
   <div class="container">
       <div class="row">
           <div class="col-12">
-              &copy; 2010-2015 <a href="http://pydanny.com">Daniel Greenfeld</a>, <a href="http://www.audreymroy.com">Audrey Roy</a> & <a href="http://www.cartwheelweb.com/">Cartwheel Web</a>
+              &copy; 2010-2016 <a href="http://pydanny.com">Daniel Greenfeld</a>, <a href="http://www.audreymroy.com">Audrey Roy</a> & <a href="http://www.cartwheelweb.com/">Cartwheel Web</a>
           </div>
       </div>
   </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -48,7 +48,7 @@
   <div class="container">
       <div class="row">
           <div class="col-12">
-              &copy; 2010-2015 <a href="http://pydanny.com">Daniel Greenfeld</a>, <a href="http://www.audreymroy.com">Audrey Roy</a> & <a href="http://www.cartwheelweb.com/">Cartwheel Web</a>
+              &copy; 2010-{% now "Y" %} <a href="http://pydanny.com">Daniel Greenfeld</a>, <a href="http://www.audreymroy.com">Audrey Roy</a> & <a href="http://www.cartwheelweb.com/">Cartwheel Web</a>
           </div>
       </div>
   </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -153,7 +153,7 @@
   <div class="container">
       <div class="row">
           <div class="col-12">
-              &copy; 2010-2016 <a href="http://pydanny.com">Daniel Greenfeld</a>, <a href="http://www.audreymroy.com">Audrey Roy</a> & <a href="https://twoscoops.academy">Two Scoops Academy</a>
+              &copy; 2010-{% now "Y" %} <a href="http://pydanny.com">Daniel Greenfeld</a>, <a href="http://www.audreymroy.com">Audrey Roy</a> & <a href="https://twoscoops.academy">Two Scoops Academy</a>
               - <a href="https://github.com/pydanny/djangopackages">Repo</a>
               - <a href="{% url 'faq' %}">{% trans "FAQ" %}</a>
               - <a href="{% url 'terms' %}">{% trans "Terms" %}</a>


### PR DESCRIPTION
I noticed that the year in the footer was out of date so I updated it.

I fixed the templates when I could so that it now automatically displays the current year.

However, I was not able to do that in the static HTML pages (error.html and maintenance.html) so on those pages I just incremented the year.

I also tried to use a dynamic year in the sphinx configuration file but I'm not sure if that's a valid solution.


Thanks!