### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ https://www.djangopackages.com.
 The Documentation
 -----------------
 
-The documentation is hosted at http://djangopackages.rtfd.org
+The documentation is hosted at https://djangopackages.readthedocs.io
 
 License
 -------
@@ -61,7 +61,7 @@ Credits
 
 For Django Dash 2010, `@pydanny`_ and `@audreyr`_ created `Django Packages`_.
 
-They are joined by a host of core developers and contributors.  See http://opencomparison.readthedocs.org/en/latest/contributors.html
+They are joined by a host of core developers and contributors.  See https://opencomparison.readthedocs.io/en/latest/contributors.html
 
 .. _`@pydanny`: https://github.com/pydanny/
 .. _`@audreyr`: https://github.com/audreyr/

--- a/core/apiv1.py
+++ b/core/apiv1.py
@@ -5,7 +5,7 @@ Please switch to APIv3:
 
 <ul>
     <li><a href="https://www.djangopackages.com/api/v3/">APIv3 Endpoint</a></li>
-    <li><a href="http://djangopackages.readthedocs.org/en/latest/apiv3_docs.html">APIv3 Documentation</a></li>
+    <li><a href="https://djangopackages.readthedocs.io/en/latest/apiv3_docs.html">APIv3 Documentation</a></li>
     <li><a href="http://www.pydanny.com/phasing-out-django-packages-apiv1-apiv2.html">APIv1 end-of-life notification</a></li>
 </ul>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -158,7 +158,7 @@
               - <a href="{% url 'faq' %}">{% trans "FAQ" %}</a>
               - <a href="{% url 'terms' %}">{% trans "Terms" %}</a>
               - <a href="{% url 'contribute' %}">{% trans "Contribute" %}</a>
-              - <a href="http://djangopackages.readthedocs.org/en/latest/apiv3_docs.html">{% trans "API" %}</a>
+              - <a href="https://djangopackages.readthedocs.io/en/latest/apiv3_docs.html">{% trans "API" %}</a>
               - <a href="{% url 'syndication' %}">{% trans "RSS / Atom" %}</a>
           </div>
       </div>

--- a/templates/pages/contribute.html
+++ b/templates/pages/contribute.html
@@ -17,8 +17,8 @@ This is an entirely volunteer driven effort. That includes coding time and hosti
 
 <h3>Contributing code</h3>
 
-<p>This project has had over <a href="http://opencomparison.readthedocs.org/en/latest/contributors.html">30 contributors</a> whose work has seen this project move forward in leaps and bounds. If you want help out, please read the <a href="http://opencomparison.readthedocs.org/en/latest/contributing.html">contributing instructions</a>. You
-should also read the <a href="http://opencomparison.readthedocs.org/en/latest/faq.html#installation">Installation Section of the Open Comparison FAQ</a>.
+<p>This project has had over <a href="https://opencomparison.readthedocs.io/en/latest/contributors.html">30 contributors</a> whose work has seen this project move forward in leaps and bounds. If you want help out, please read the <a href="https://opencomparison.readthedocs.io/en/latest/contributing.html">contributing instructions</a>. You
+should also read the <a href="https://opencomparison.readthedocs.io/en/latest/faq.html#installation">Installation Section of the Open Comparison FAQ</a>.
 </p>
 
 {% endblock body %}


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.